### PR TITLE
refactor/ fetch api converted to GET method

### DIFF
--- a/src/app/api/course/[slug]/route.ts
+++ b/src/app/api/course/[slug]/route.ts
@@ -10,16 +10,16 @@ import { authOptions } from "../../auth/constants";
 import editCourse_ from "../edit";
 import createCourse_ from "../create";
 
-const schoolApiHandler_ = async function POST(
+const coursePostApiHandler_ = async function POST(
   req: Request,
 
-  { params }: { params: { slug: string } }
+  { params }: { params: { slug: string } },
 ) {
   const session = await getServerSession(authOptions);
 
   const slug = params.slug;
 
-  const schoolFunctions: {
+  const CourseFunctions: {
     [key: string]: (request: Request, session?: Session) => {};
   } = {
     createCourse: createCourse_,
@@ -30,8 +30,8 @@ const schoolApiHandler_ = async function POST(
     findCourseByName: findCourseByName_,
   };
 
-  if (schoolFunctions[slug] && session) {
-    return schoolFunctions[slug](req, session);
+  if (CourseFunctions[slug] && session) {
+    return CourseFunctions[slug](req, session);
   } else {
     const response = {
       isError: true,
@@ -44,4 +44,35 @@ const schoolApiHandler_ = async function POST(
   }
 };
 
-export { schoolApiHandler_ as POST };
+const courseGetApiHandler_ = async function POST(
+  req: Request,
+
+  { params }: { params: { slug: string } },
+) {
+  const session = await getServerSession(authOptions);
+
+  const slug = params.slug;
+
+  const CourseFunctions: {
+    [key: string]: (request: Request, session?: Session) => {};
+  } = {
+    fetchCourses: fetchCourses_,
+    fetchCourseById: fetchCourseById_,
+    findCourseByName: findCourseByName_,
+  };
+
+  if (CourseFunctions[slug] && session) {
+    return CourseFunctions[slug](req, session);
+  } else {
+    const response = {
+      isError: true,
+      code: SPARKED_PROCESS_CODES.METHOD_NOT_FOUND,
+    };
+
+    return new Response(JSON.stringify(response), {
+      status: 200,
+    });
+  }
+};
+
+export { coursePostApiHandler_ as POST, courseGetApiHandler_ as GET };

--- a/src/app/links.ts
+++ b/src/app/links.ts
@@ -25,7 +25,7 @@ export const API_LINKS: T_link = {
   FETCH_COURSE_BY_ID: '/api/course/fetchCourseById',
   EDIT_COURSE: '/api/course/editCourse',
   DELETE_COURSES: '/api/course/deleteCourse',
-  FIND_COURSE_BY_NAME: '/api/course/findCourseByName',
+  FIND_COURSE_BY_NAME: '/api/course/findCourseByName?',
   // unit  links
   CREATE_UNIT: '/api/unit/createUnit',
   FETCH_UNIT: '/api/unit/fetchUnits',

--- a/src/hooks/useCourse/index.ts
+++ b/src/hooks/useCourse/index.ts
@@ -240,22 +240,17 @@ const useCourse = (form?: any) => {
     }
 
     const url = API_LINKS.FIND_COURSE_BY_NAME;
-    const formData = {
-      body: JSON.stringify({
-        name: searchQuery.trim(),
-        limit: 1000,
-        skip: 0,
-        withMetaData,
-      }),
-      method: 'post',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    };
+
+    const params = new URLSearchParams({
+      name: searchQuery.trim(),
+      limit: '1000',
+      skip: '0',
+      withMetaData: 'true',
+    });
 
     try {
       setLoaderStatus(true);
-      const resp = await fetch(url, formData);
+      const resp = await fetch(url + params);
       setLoaderStatus(false);
 
       if (!resp.ok) {


### PR DESCRIPTION
# Refactor/ fetch api converted to GET method


# Screen shots 
### Before
     

 ### After
  

 ### Breaking changes 
- The following end points should now use `GET` method:

1. `fetchCourses`
2.  `fetchCourseById`
3.  `findCourseByName`

FYI:   @YewoMhango 
cc:     @OlivierJM 
